### PR TITLE
Added utils for strings and collections comparison with enhanced output

### DIFF
--- a/src/Unicorn.Taf.Core/Utility/CollectionsComparer.cs
+++ b/src/Unicorn.Taf.Core/Utility/CollectionsComparer.cs
@@ -12,7 +12,7 @@ namespace Unicorn.Taf.Core.Utility
     ///  - contains
     ///  - does not contain
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">collections items types</typeparam>
     public class CollectionsComparer<T>
     {
         private const string NotExpected = "Not expected items >>";
@@ -55,7 +55,7 @@ namespace Unicorn.Taf.Core.Utility
         /// <param name="actual">actual items collection</param>
         /// <param name="expected">expected items collection</param>
         /// <returns>true if actual collection is sequence equal to another; otherwise - false</returns>
-        public bool AreSequenceEqualTo(IEnumerable<T> actual, IEnumerable<T> expected)
+        public bool AreSequenceEqual(IEnumerable<T> actual, IEnumerable<T> expected)
         {
             StringBuilder diff = new StringBuilder();
 
@@ -220,15 +220,13 @@ namespace Unicorn.Taf.Core.Utility
 
             foreach (T item in second)
             {
-                int hits;
-                dict.TryGetValue(item, out hits);
+                dict.TryGetValue(item, out int hits);
                 dict[item] = hits + 1;
             }
 
             foreach (T item in first)
             {
-                int hits;
-                dict.TryGetValue(item, out hits);
+                dict.TryGetValue(item, out int hits);
                 if (hits > 0)
                 {
                     yield return item;

--- a/src/Unicorn.Taf.Core/Utility/CollectionsComparer.cs
+++ b/src/Unicorn.Taf.Core/Utility/CollectionsComparer.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Unicorn.Taf.Core.Utility
+{
+    /// <summary>
+    /// Utility for collections comparison. Available modes:
+    ///  - equality ignoring order
+    ///  - sequential equality
+    ///  - contains
+    ///  - does not contain
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class CollectionsComparer<T>
+    {
+        private const string NotExpected = "Not expected items >>";
+        private const string Absent = "Absent items >>";
+        private const string Diff = "Diff >>";
+
+        private string delimiter = Environment.NewLine;
+        private int trimLength = int.MaxValue;
+
+        /// <summary>
+        /// Trims diff output by specified symbols count.
+        /// </summary>
+        /// <param name="limit">output length limit</param>
+        /// <returns></returns>
+        public CollectionsComparer<T> TrimOutputTo(int limit)
+        {
+            trimLength = limit;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds custom bullet when appending items in diff output.
+        /// </summary>
+        /// <param name="bullet">bullet value</param>
+        /// <returns></returns>
+        public CollectionsComparer<T> UseItemsBulletsInOutput(string bullet)
+        {
+            delimiter = Environment.NewLine + bullet + " ";
+            return this;
+        }
+
+        /// <summary>
+        /// Gets detailed diff results as string
+        /// </summary>
+        public string Output { get; private set; }
+
+        /// <summary>
+        /// Checks whether actual collection is sequence equal to another.
+        /// </summary>
+        /// <param name="actual">actual items collection</param>
+        /// <param name="expected">expected items collection</param>
+        /// <returns>true if actual collection is sequence equal to another; otherwise - false</returns>
+        public bool AreSequenceEqualTo(IEnumerable<T> actual, IEnumerable<T> expected)
+        {
+            StringBuilder diff = new StringBuilder();
+
+            int actualCount = actual.Count();
+            int expectedCount = expected.Count();
+
+            diff.Append(Diff);
+
+            for (int i = 0; i < Math.Min(actualCount, expectedCount); i++)
+            {
+                if (!actual.ElementAt(i).Equals(expected.ElementAt(i)))
+                {
+                    diff.Append(delimiter).AppendFormat("[Index {0}]", i).AppendLine()
+                        .Append("    Expected >> ").Append(expected.ElementAt(i)).AppendLine()
+                        .Append("      Actual >> ").Append(actual.ElementAt(i));
+                }
+            }
+
+            if (diff.Length == Diff.Length)
+            {
+                diff.Clear();
+            }
+            else
+            {
+                diff.AppendLine().AppendLine();
+            }
+
+            if (expectedCount > actualCount)
+            {
+                FillDiffWith(diff, Absent + $" (starting from index {actualCount})", expected.Skip(actualCount));
+            }
+
+            if (actualCount > expectedCount)
+            {
+                FillDiffWith(diff, NotExpected + $" (starting from index {expectedCount})", actual.Skip(expectedCount));
+            }
+            Truncate(diff);
+
+            bool areSequenceEqual = diff.Length == 0;
+            Output = areSequenceEqual ? "Collections are sequence equal" : diff.ToString();
+            return areSequenceEqual;
+        }
+
+        /// <summary>
+        /// Checks whether actual collection has the same items as expected collection ignoring order.
+        /// </summary>
+        /// <param name="actual">actual items collection</param>
+        /// <param name="expected">expected items collection</param>
+        /// <returns>true if actual collection has the same items as expected collection ignoring order; otherwise - false</returns>
+        public bool AreTheSame(IEnumerable<T> actual, IEnumerable<T> expected)
+        {
+            IEnumerable<T> intersection = IntersectWithDuplicates(actual, expected);
+
+            List<T> absent = expected.ToList();
+            List<T> redundant = actual.ToList();
+
+            for (var i = 0; i < intersection.Count(); i++)
+            {
+                absent.Remove(intersection.ElementAt(i));
+                redundant.Remove(intersection.ElementAt(i));
+            }
+
+            StringBuilder diff = new StringBuilder();
+
+            if (absent.Any())
+            {
+                FillDiffWith(diff, Absent, absent);
+                diff.AppendLine();
+            }
+
+            if (redundant.Any())
+            {
+                FillDiffWith(diff, NotExpected, redundant);
+            }
+
+            Truncate(diff);
+
+            bool areTheSame = !absent.Any() && !redundant.Any();
+
+            Output = areTheSame ? "Collections are the same" : diff.ToString();
+            return areTheSame;
+        }
+
+        /// <summary>
+        /// Checks whether actual collection contains all items from expected collection
+        /// </summary>
+        /// <param name="actual">actual items collection</param>
+        /// <param name="expected">expected items collection</param>
+        /// <returns>true if actual collection contains all items from expected collection; otherwise - false</returns>
+        public bool Contains(IEnumerable<T> actual, IEnumerable<T> expected)
+        {
+            IEnumerable<T> intersection = actual.Intersect(expected);
+
+            if (intersection.Count() == expected.Count())
+            {
+                Output = "Collection contains all specified items";
+                return true;
+            }
+
+            List<T> absent = expected.ToList();
+
+            for (var i = 0; i < intersection.Count(); i++)
+            {
+                absent.Remove(intersection.ElementAt(i));
+            }
+
+            StringBuilder diff = new StringBuilder();
+            FillDiffWith(diff, "Absent items >>", absent);
+            Truncate(diff);
+
+            Output = diff.ToString();
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks whether actual collection does not contain all items from expected collection.
+        /// </summary>
+        /// <param name="actual">actual items collection</param>
+        /// <param name="expected">expected items collection</param>
+        /// <returns>true if actual collection does not contain all items from expected collection; otherwise - false</returns>
+        public bool NotContains(IEnumerable<T> actual, IEnumerable<T> expected)
+        {
+            IEnumerable<T> intersection = actual.Intersect(expected);
+
+            if (intersection.Any())
+            {
+                StringBuilder diff = new StringBuilder();
+                FillDiffWith(diff, NotExpected, intersection);
+                Truncate(diff);
+                
+                Output = diff.ToString();
+                return false;
+            }
+
+            Output = "Collection does not contain all specified items";
+            return true;
+        }
+
+        private void Truncate(StringBuilder data)
+        {
+            if (data.Length > trimLength)
+            {
+                data.Length = trimLength;
+                data.AppendLine().AppendLine().AppendFormat("<< truncated by {0} symbols", trimLength);
+            }
+        }
+
+        private void FillDiffWith(StringBuilder diff, string title, IEnumerable<T> items)
+        {
+            diff.Append(title);
+
+            foreach(T item in items)
+            {
+                diff.Append(delimiter).Append(item);
+            }
+        }
+
+        private static IEnumerable<T> IntersectWithDuplicates(IEnumerable<T> first, IEnumerable<T> second)
+        {
+            var dict = new Dictionary<T, int>();
+
+            foreach (T item in second)
+            {
+                int hits;
+                dict.TryGetValue(item, out hits);
+                dict[item] = hits + 1;
+            }
+
+            foreach (T item in first)
+            {
+                int hits;
+                dict.TryGetValue(item, out hits);
+                if (hits > 0)
+                {
+                    yield return item;
+                    dict[item] = hits - 1;
+                }
+            }
+        }
+    }
+}

--- a/src/Unicorn.Taf.Core/Verification/Matchers/CollectionMatchers/HasItemsMatcher.cs
+++ b/src/Unicorn.Taf.Core/Verification/Matchers/CollectionMatchers/HasItemsMatcher.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using Unicorn.Taf.Core.Utility;
 
 namespace Unicorn.Taf.Core.Verification.Matchers.CollectionMatchers
 {
@@ -39,13 +40,24 @@ namespace Unicorn.Taf.Core.Verification.Matchers.CollectionMatchers
                 return Reverse;
             }
 
-            var mismatchItems = Reverse ?
-                actual.Where(i => _expectedObjects.Contains(i)) :
-                _expectedObjects.Where(i => !actual.Contains(i));
+            CollectionsComparer<T> comparer = new CollectionsComparer<T>()
+                .TrimOutputTo(1000)
+                .UseItemsBulletsInOutput(">");
 
-            DescribeMismatch($"items {(Reverse ? "" : "not ")}presented: {string.Join(", ", mismatchItems)}");
+            bool result;
 
-            return mismatchItems.Any() ? Reverse : !Reverse;
+            if (Reverse)
+            {
+                result = !comparer.NotContains(actual, _expectedObjects);
+                DescribeMismatch(Environment.NewLine + comparer.Output);
+            }
+            else
+            {
+                result = comparer.Contains(actual, _expectedObjects);
+                DescribeMismatch(Environment.NewLine + comparer.Output);
+            }
+
+            return result;
         }
     }
 }

--- a/src/Unicorn.Taf.Core/Verification/Matchers/CollectionMatchers/SequenceEqualToCollectionMatcher.cs
+++ b/src/Unicorn.Taf.Core/Verification/Matchers/CollectionMatchers/SequenceEqualToCollectionMatcher.cs
@@ -44,7 +44,7 @@ namespace Unicorn.Taf.Core.Verification.Matchers.CollectionMatchers
                 .TrimOutputTo(1000)
                 .UseItemsBulletsInOutput(">");
 
-            bool result = comparer.AreSequenceEqualTo(actual, _expected);
+            bool result = comparer.AreSequenceEqual(actual, _expected);
             DescribeMismatch(Environment.NewLine + comparer.Output);
             return result;
         }

--- a/src/Unicorn.Taf.Core/Verification/Matchers/CollectionMatchers/SequenceEqualToCollectionMatcher.cs
+++ b/src/Unicorn.Taf.Core/Verification/Matchers/CollectionMatchers/SequenceEqualToCollectionMatcher.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using Unicorn.Taf.Core.Utility;
 
 namespace Unicorn.Taf.Core.Verification.Matchers.CollectionMatchers
 {
@@ -39,8 +40,13 @@ namespace Unicorn.Taf.Core.Verification.Matchers.CollectionMatchers
                 return Reverse;
             }
 
-            DescribeMismatch(DescribeCollection(actual, 1000));
-            return actual.SequenceEqual(_expected);
+            CollectionsComparer<T> comparer = new CollectionsComparer<T>()
+                .TrimOutputTo(1000)
+                .UseItemsBulletsInOutput(">");
+
+            bool result = comparer.AreSequenceEqualTo(actual, _expected);
+            DescribeMismatch(Environment.NewLine + comparer.Output);
+            return result;
         }
     }
 }

--- a/src/Unicorn.Taf.Core/Verification/Matchers/CollectionMatchers/TheSameAsCollectionMatcher.cs
+++ b/src/Unicorn.Taf.Core/Verification/Matchers/CollectionMatchers/TheSameAsCollectionMatcher.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using Unicorn.Taf.Core.Utility;
 
 namespace Unicorn.Taf.Core.Verification.Matchers.CollectionMatchers
 {
@@ -39,33 +40,13 @@ namespace Unicorn.Taf.Core.Verification.Matchers.CollectionMatchers
                 return Reverse;
             }
 
-            var counts = _expectedObjects
-                .GroupBy(v => v)
-                .ToDictionary(g => g.Key, g => g.Count());
-            var ok = true;
+            CollectionsComparer<T> comparer = new CollectionsComparer<T>()
+                .TrimOutputTo(1000)
+                .UseItemsBulletsInOutput(">");
 
-            foreach (var n in actual)
-            {
-                int c;
-                if (counts.TryGetValue(n, out c))
-                {
-                    counts[n] = c - 1;
-                }
-                else
-                {
-                    ok = false;
-                    break;
-                }
-            }
-
-            var areEqual = ok && counts.Values.All(c => c == 0);
-
-            if (areEqual == Reverse)
-            {
-                DescribeMismatch(DescribeCollection(actual, 1000));
-            }
-
-            return areEqual;
+            bool result = comparer.AreTheSame(actual, _expectedObjects);
+            DescribeMismatch(Environment.NewLine + comparer.Output);
+            return result;
         }
     }
 }

--- a/src/Unicorn.Taf.Core/Verification/Matchers/CoreMatchers/EqualToMatcher.cs
+++ b/src/Unicorn.Taf.Core/Verification/Matchers/CoreMatchers/EqualToMatcher.cs
@@ -1,4 +1,6 @@
-﻿namespace Unicorn.Taf.Core.Verification.Matchers.CoreMatchers
+﻿using System;
+
+namespace Unicorn.Taf.Core.Verification.Matchers.CoreMatchers
 {
     /// <summary>
     /// Matcher to check if object is equal to expected one. 
@@ -20,7 +22,7 @@
         /// <summary>
         /// Gets check description.
         /// </summary>
-        public override string CheckDescription => "is equal to " + _objectToCompare;
+        public override string CheckDescription => $"is equal to '{_objectToCompare}'";
 
         /// <summary>
         /// Checks if object is equal to expected one.
@@ -35,7 +37,17 @@
                 return Reverse;
             }
 
-            DescribeMismatch(actual.ToString());
+            // Enhanced outputs for strings
+            if (actual is string && !Reverse)
+            {
+                string diff = MatchersUtils.GetStringsDiff(actual.ToString(), _objectToCompare.ToString());
+                DescribeMismatch(Environment.NewLine + diff);
+            }
+            else
+            {
+                DescribeMismatch(actual.ToString());
+            }
+
             return actual.Equals(_objectToCompare);
         }
     }

--- a/src/Unicorn.Taf.Core/Verification/Matchers/MatchersUtils.cs
+++ b/src/Unicorn.Taf.Core/Verification/Matchers/MatchersUtils.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Text;
+
+namespace Unicorn.Taf.Core.Verification.Matchers
+{
+    /// <summary>
+    /// Useful utilities for matchers and comparison
+    /// </summary>
+    public class MatchersUtils
+    {
+        private const string More = " . . . ";
+
+        /// <summary>
+        /// Gets enhanced result of strings comparison pointing on first exact diff place.
+        /// </summary>
+        /// <param name="expected">expected string</param>
+        /// <param name="actual">actual string</param>
+        /// <returns>60 chars window around first diff with pointer to the diff 
+        /// or 'Strings are identical' if strings are identical</returns>
+        public static string GetStringsDiff(string expected, string actual)
+        {
+            string expectedHeader = "Expected >> ";
+            string actualHeader = "  Actual >> ";
+
+            StringBuilder diff = new StringBuilder();
+
+            int diffIndex = FindFirstDifference(expected, actual);
+
+            if (diffIndex == -1)
+            {
+                return "Strings are identical";
+            }
+
+            int takeFrom = diffIndex - 30;
+            int takeTill = diffIndex + 31;
+
+            // Calculate windows boundaries
+            int start = Math.Max(0, takeFrom);
+            int actualEnd = Math.Min(actual.Length, takeTill);
+            int expectedEnd = Math.Min(expected.Length, takeTill);
+
+            if (start > 0)
+            {
+                expectedHeader += More;
+                actualHeader += More;
+            }
+
+            diff.Append(expectedHeader).Append(expected.Substring(start, expectedEnd - start));
+            diff.AppendLine(takeTill < expected.Length ? More : "");
+
+            diff.Append(actualHeader).Append(actual.Substring(start, actualEnd - start));
+            diff.AppendLine(takeTill < actual.Length ? More : "");
+
+            // Print marker line
+            for (int i = 0; i < diffIndex - start + expectedHeader.Length; i++)
+            {
+                diff.Append('-');
+            }
+
+            diff.Append("^ at index ").Append(diffIndex);
+
+            return diff.ToString();
+        }
+
+        private static int FindFirstDifference(string str1, string str2)
+        {
+            int length = Math.Min(str1.Length, str2.Length);
+
+            for (int i = 0; i < length; i++)
+            {
+                if (str1[i] != str2[i])
+                {
+                    return i;
+                }
+            }
+
+            // If one string is longer than the other
+            return str1.Length == str2.Length ? -1 : Math.Min(str1.Length, str2.Length);
+        }
+    }
+}

--- a/src/Unicorn.UnitTests/Tests/Core/Testing/StepsFeature.cs
+++ b/src/Unicorn.UnitTests/Tests/Core/Testing/StepsFeature.cs
@@ -42,7 +42,7 @@ namespace Unicorn.UnitTests.Tests.Core.Testing
             new TestsRunner(Assembly.GetExecutingAssembly(), false).RunTests();
             Assert.That(
                 Output, 
-                Is.EqualTo("Test1AfterTestAssert that Test2 is equal to Test2AfterTestAfterSuite"));
+                Is.EqualTo("Test1AfterTestAssert that Test2 is equal to 'Test2'AfterTestAfterSuite"));
         }
 
         [Author("Vitaliy Dobriyan")]

--- a/src/Unicorn.UnitTests/Tests/Core/Utility/CollectionsComparerTests.cs
+++ b/src/Unicorn.UnitTests/Tests/Core/Utility/CollectionsComparerTests.cs
@@ -1,0 +1,102 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using Unicorn.Taf.Core.Utility;
+using Unicorn.UnitTests.Util;
+
+namespace Unicorn.UnitTests.Tests.Core.Utility
+{
+    [TestFixture]
+    public class CollectionsComparerTests : NUnitTestRunner
+    {
+        private CollectionsComparer<string> stringComparer = new CollectionsComparer<string>();
+        private CollectionsComparer<int> intComparer = new CollectionsComparer<int>();
+
+        [Test]
+        public void TestCollectionsComparerHasSameItemsEqualPositive() =>
+            Assert.IsTrue(stringComparer.AreTheSame(
+                StringCollectionFromRange(0, 25), StringCollectionFromRange(0, 25)));
+
+        [Test]
+        public void TestCollectionsComparerHasSameItemsNegative() =>
+            Assert.IsFalse(stringComparer.AreTheSame(
+                StringCollectionFromRange(0, 23), StringCollectionFromRange(0, 25)));
+
+        [Test]
+        public void TestCollectionsComparerHasSameItemsReverseNegative() =>
+                Assert.IsFalse(stringComparer.AreTheSame(
+                StringCollectionFromRange(0, 23), StringCollectionFromRange(0, 25).Reverse()));
+
+        [Test]
+        public void TestCollectionsComparerHasSameItemsEqualReversedWithDuplicatesIntNegative() =>
+            Assert.IsFalse(intComparer.AreTheSame(
+                new[] { 1, 2, 3, 4, 5 }, new[] { 1, 2, 3, 4, 5, 2 }));
+
+        [Test]
+        public void TestCollectionsComparerHasSameItemsEqualReversedWithDuplicatesViceVersaIntNegative() =>
+            Assert.IsFalse(intComparer.AreTheSame(
+                new[] { 1, 2, 3, 4, 5, 2 }, new[] { 1, 2, 3, 4, 5 }));
+
+        [Test]
+        public void TestCollectionsComparerHasSameItemsEqualReversedPositive() =>
+            Assert.IsTrue(stringComparer.AreTheSame(
+                StringCollectionFromRange(0, 25), StringCollectionFromRange(0, 25).Reverse()));
+
+        [Test]
+        public void TestCollectionsComparerHasSameItemsEqualReversedIntPositive() =>
+            Assert.IsTrue(intComparer.AreTheSame(
+                IntCollectionFromRange(0, 25), IntCollectionFromRange(0, 25)));
+
+        [Test]
+        public void TestCollectionsComparerContainsEqualIntPositive() =>
+            Assert.IsTrue(intComparer.Contains(
+                IntCollectionFromRange(0, 25), IntCollectionFromRange(0, 25)));
+
+        [Test]
+        public void TestCollectionsComparerContainsEqualStringReversedPositive() =>
+            Assert.IsTrue(stringComparer.Contains(
+                StringCollectionFromRange(0, 25), StringCollectionFromRange(0, 25).Reverse()));
+
+        [Test]
+        public void TestCollectionsComparerContainsStringReversedPositive() =>
+            Assert.IsTrue(stringComparer.Contains(
+                StringCollectionFromRange(0, 26), StringCollectionFromRange(1, 23).Reverse()));
+
+        [Test]
+        public void TestCollectionsComparerContainsNegative() =>
+                Assert.IsFalse(stringComparer.Contains(
+                StringCollectionFromRange(0, 23), StringCollectionFromRange(0, 25).Reverse()));
+
+        [Test]
+        public void TestCollectionsComparerContainsNoInterceptionNegative() =>
+                Assert.IsFalse(stringComparer.Contains(
+                StringCollectionFromRange(0, 5), StringCollectionFromRange(6, 7).Reverse()));
+
+        [Test]
+        public void TestCollectionsComparerNotContainsEqualStringPositive() =>
+            Assert.IsTrue(stringComparer.NotContains(
+                StringCollectionFromRange(0, 25), StringCollectionFromRange(26, 27)));
+
+        [Test]
+        public void TestCollectionsComparerNotContainsEqualStringReversePositive() =>
+            Assert.IsTrue(stringComparer.NotContains(
+                StringCollectionFromRange(0, 25), StringCollectionFromRange(26, 27).Reverse()));
+
+
+        [Test]
+        public void TestCollectionsComparerNotContainsNoInterceptionEqualsNegative() =>
+                Assert.IsFalse(stringComparer.NotContains(
+                StringCollectionFromRange(0, 5), StringCollectionFromRange(0, 5).Reverse()));
+
+        [Test]
+        public void TestCollectionsComparerNotContainsNoInterceptionIntersectionNegative() =>
+                Assert.IsFalse(stringComparer.NotContains(
+                StringCollectionFromRange(0, 5), StringCollectionFromRange(2, 3).Reverse()));
+
+        private static IEnumerable<string> StringCollectionFromRange(int from, int to) =>
+            Enumerable.Range(from, to - from).Select(i => "string" + i);
+
+        private static List<int> IntCollectionFromRange(int from, int to) =>
+            Enumerable.Range(from, to - from).ToList();
+    }
+}

--- a/src/Unicorn.UnitTests/Tests/Core/Utility/DebugOutputCollectionsComparerTests.cs
+++ b/src/Unicorn.UnitTests/Tests/Core/Utility/DebugOutputCollectionsComparerTests.cs
@@ -1,0 +1,99 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Unicorn.Taf.Core.Utility;
+using Unicorn.Taf.Core.Verification.Matchers;
+using Unicorn.UnitTests.Util;
+using Verify = Unicorn.Taf.Core.Verification;
+
+namespace Unicorn.UnitTests.Tests.Core.Utility
+{
+    [TestFixture]
+    public class DebugOutputCollectionsComparerTests : NUnitTestRunner
+    {
+        //[Test] // Need to debug output
+        public void TestCollectionsComparerOutput()
+        {
+            CollectionsComparer<int> comparer = new CollectionsComparer<int>()
+                .TrimOutputTo(500)
+                .UseItemsBulletsInOutput(">");
+
+            CollectionsComparer<string> strComparer = new CollectionsComparer<string>()
+                .TrimOutputTo(50)
+                .UseItemsBulletsInOutput(" ");
+
+            string diff = "AreSequenceEqualTo" + Environment.NewLine;
+            comparer.AreSequenceEqualTo(new[] { 1, 2, 3, 4, }, new[] { 1, 2, 5, 4, 6 });
+            diff += comparer.Output + Environment.NewLine + new string('-', 60) + Environment.NewLine + Environment.NewLine;
+
+            diff += "AreTheSame" + Environment.NewLine;
+            comparer.AreTheSame(new[] { 1, 2, 3, 4 }, new[] { 1, 2, 5, 4, 6 });
+            diff += comparer.Output + Environment.NewLine + new string('-', 60) + Environment.NewLine + Environment.NewLine;
+
+            diff += "Contains" + Environment.NewLine;
+            strComparer.Contains(StringsCollection(2, 5), StringsCollection(1, 6));
+            diff += strComparer.Output + Environment.NewLine + new string('-', 60) + Environment.NewLine + Environment.NewLine;
+
+            diff += "NotContains" + Environment.NewLine;
+            comparer.NotContains(IntsCollection(2, 5), IntsCollection(1, 6));
+            diff += comparer.Output;
+
+            Assert.Fail(diff);
+        }
+
+        //[Test] // Need to debug output
+        public void TestCollectionsComparerOutput1()
+        {
+            string diff = MatchersUtils.GetStringsDiff(
+                "edkfj@asldkfj#sdfsdfsdf",
+                "edkfj@asldkfj#1sdfsdfsdf");
+
+            diff += Environment.NewLine;
+
+            diff += MatchersUtils.GetStringsDiff(
+                "edkfj@asldkfj#sdfsdfsdf",
+                "edkfj@asldkfj#1");
+
+            diff += Environment.NewLine;
+
+            diff += MatchersUtils.GetStringsDiff(
+                "edkfj@asldkfj#s",
+                "edkfj@asldkfj#1esrgdlhlkdfjsgh90845gh945gh0345698gh9453g8h");
+
+            diff += Environment.NewLine;
+
+            diff += MatchersUtils.GetStringsDiff(
+                "sdfgdflsgkhjf8943tdg5667dfklvjh569ghbedkfj@asldkfj#ssdfgdflsgkhjf8943tdg5667dfklvjh569ghb",
+                "sdfgdflsgkhjf8943tdg5667dfklvjh569ghbedkfj@asldkfj#1sdfgdflsgkhjf8943tdg5667dfklvjh569ghb");
+
+            Assert.Fail(diff);
+        }
+
+        //[Test] // Need to debug output
+        public void SequenceEqualTo() =>
+            Verify.Assert.That(StringsCollection(2, 7), 
+                Collection.IsSequenceEqualTo(StringsCollection(2, 9)));
+
+        //[Test] // Need to debug output
+        public void IsTheSameAs() =>
+            Verify.Assert.That(new[] { 1, 2, 3, 4 }, 
+                Collection.IsTheSameAs(new[] { 1, 2, 5, 4, 6 }));
+
+        //[Test] // Need to debug output
+        public void Contains() =>
+            Verify.Assert.That(StringsCollection(2, 5),
+                Collection.HasItems(StringsCollection(1, 6)));
+
+        //[Test] // Need to debug output
+        public void NotContains() =>
+            Verify.Assert.That(StringsCollection(2, 5),
+                Verify.Matchers.Is.Not(Collection.HasItems(StringsCollection(1, 6))));
+        
+        private static IEnumerable<string> StringsCollection(int from, int to) =>
+            Enumerable.Range(from, to - from + 1).Select(i => "string" + i);
+
+        private static List<int> IntsCollection(int from, int to) =>
+            Enumerable.Range(from, to - from + 1).ToList();
+    }
+}

--- a/src/Unicorn.UnitTests/Tests/Core/Utility/DebugOutputCollectionsComparerTests.cs
+++ b/src/Unicorn.UnitTests/Tests/Core/Utility/DebugOutputCollectionsComparerTests.cs
@@ -24,7 +24,7 @@ namespace Unicorn.UnitTests.Tests.Core.Utility
                 .UseItemsBulletsInOutput(" ");
 
             string diff = "AreSequenceEqualTo" + Environment.NewLine;
-            comparer.AreSequenceEqualTo(new[] { 1, 2, 3, 4, }, new[] { 1, 2, 5, 4, 6 });
+            comparer.AreSequenceEqual(new[] { 1, 2, 3, 4, }, new[] { 1, 2, 5, 4, 6 });
             diff += comparer.Output + Environment.NewLine + new string('-', 60) + Environment.NewLine + Environment.NewLine;
 
             diff += "AreTheSame" + Environment.NewLine;


### PR DESCRIPTION
## Examples of string diffs reporting
```
Expected >> edkfj@asldkfj#sdfsdfsdf
  Actual >> edkfj@asldkfj#1sdfsdfsdf
--------------------------^ at index 14
Expected >> edkfj@asldkfj#sdfsdfsdf
  Actual >> edkfj@asldkfj#1
--------------------------^ at index 14
Expected >> edkfj@asldkfj#s
  Actual >> edkfj@asldkfj#1esrgdlhlkdfjsgh90845gh945gh034 . . . 
--------------------------^ at index 14
Expected >>  . . . 667dfklvjh569ghbedkfj@asldkfj#ssdfgdflsgkhjf8943tdg5667dfklvj . . . 
  Actual >>  . . . 667dfklvjh569ghbedkfj@asldkfj#1sdfgdflsgkhjf8943tdg5667dfklvj . . . 
-------------------------------------------------^ at index 51
```

## Examples of collections diff reporting
### AreSequenceEqualTo
```
Diff >>
> [Index 2]
    Expected >> 5
      Actual >> 3

Absent items >> (starting from index 4)
> 6
```

### AreTheSame
```
Absent items >>
> 5
> 6
Not expected items >>
> 3
```

### Contains
```
Absent items >>
  string1
  string6
```

### NotContains
```
Not expected items >>
> 2
> 3
> 4
> 5
```