### PR TITLE
added deep object comparer and corresponding matcher

### DIFF
--- a/src/Unicorn.Taf.Core/Utility/DeepObjectsComparer.cs
+++ b/src/Unicorn.Taf.Core/Utility/DeepObjectsComparer.cs
@@ -7,8 +7,8 @@ using System.Reflection;
 namespace Unicorn.Taf.Core.Utility
 {
     /// <summary>
-    /// Objects comparer with recursive aproach to check equality of objects considering all their public 
-    /// fields and properties values. Certain fields or properties could be excluded from comparison.
+    /// Objects comparer with recursive approach to check equality of objects considering all their public fields and 
+    /// properties values. It's possible to specify certain fields or properties to exclude them from comparison.
     /// </summary>
     public class DeepObjectsComparer
     {
@@ -49,7 +49,7 @@ namespace Unicorn.Taf.Core.Utility
         }
 
         /// <summary>
-        /// Compare two objects with recursive aproach to check their equality considering all public fields 
+        /// Compare two objects with recursive approach to check their equality considering all public fields 
         /// and properties values (primitives, objects, IEnumerable fields).
         /// It there are any ignore paths specified, then fields or properties which paths ends 
         /// with one of ignore paths will be skipped during comparison.
@@ -210,7 +210,7 @@ namespace Unicorn.Taf.Core.Utility
                 i++;
             }
 
-            // in case if enumerable2 has more items, but reacheed end of enumerable1
+            // in case if enumerable2 has more items, but reached end of enumerable1
             if (en2.MoveNext())
             {
                 differences.Add(GetDiff(newPath, "collection size differs"));

--- a/src/Unicorn.Taf.Core/Utility/DeepObjectsComparer.cs
+++ b/src/Unicorn.Taf.Core/Utility/DeepObjectsComparer.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Unicorn.Taf.Core.Utility
+{
+    /// <summary>
+    /// Objects comparer with recursive aproach to check equality of objects considering all their public fields and properties values
+    /// </summary>
+    public class DeepObjectsComparer
+    {
+        private string[] ignorePaths;
+        private string bullet;
+
+        public DeepObjectsComparer()
+        {
+            ignorePaths = new string[0];
+            bullet = string.Empty;
+        }
+
+        public DeepObjectsComparer IgnorePaths(params string[] ignorePaths)
+        {
+            this.ignorePaths = ignorePaths;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds custom bullet when appending items in diff output.
+        /// </summary>
+        /// <param name="bullet">bullet value</param>
+        /// <returns></returns>
+        public DeepObjectsComparer UseItemsBulletsInOutput(string bullet)
+        {
+            this.bullet = bullet + " ";
+            return this;
+        }
+
+        public List<string> CompareObjects(object actual, object expected) =>
+            CompareObjects(actual, expected, "");
+
+        private List<string> CompareObjects(object actual, object expected, string path)
+        {
+            var differences = new List<string>();
+
+            // Handle null cases
+            if (actual == null && expected != null)
+            {
+                differences.Add(GetDiff(path, "null", "not null"));
+                return differences;
+            }
+            else if (expected == null && actual != null)
+            {
+                differences.Add(GetDiff(path, "not null", "null"));
+                return differences;
+            }
+            else if (actual == null && expected == null)
+            {
+                return differences; // Both null, no differences
+            }
+
+            // Verify types match
+            if (!actual.GetType().Equals(expected.GetType()))
+            {
+                differences.Add(GetDiff(path, "has type: " + actual.GetType(), "has type: " + expected.GetType()));
+                return differences;
+            }
+
+            Type type = actual.GetType();
+            string currentPath = string.IsNullOrEmpty(path) ? type.Name : path;
+
+            // Compare properties
+            foreach (PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                string newPath = $"{currentPath}.{property.Name}";
+                CompareProperties(property, actual, expected, newPath, differences);
+            }
+
+            // Compare fields
+            foreach (FieldInfo field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+            {
+                string newPath = $"{currentPath}.{field.Name}";
+                CompareFields(field, actual, expected, newPath, differences);
+            }
+
+            return differences;
+        }
+
+        private void CompareProperties(PropertyInfo property, object actual, object expected, string newPath, List<string> differences)
+        {
+            // if current path ends with any entry from fields to ignore, skip this field/property
+            if (ignorePaths.Any(f => newPath.EndsWith(f)))
+            {
+                return;
+            }
+
+            // Get values
+            object value1 = property.GetValue(actual);
+            object value2 = property.GetValue(expected);
+
+            Type propertType = property.PropertyType;
+
+            // Handle primitive types and strings
+            if (propertType.IsPrimitive || propertType == typeof(string) || propertType.IsValueType)
+            {
+                ComparePrimitives(value1, value2, newPath, differences);
+            }
+            // Handle collections
+            else if (typeof(IEnumerable).IsAssignableFrom(propertType))
+            {
+                CompareCollections((IEnumerable)value1, (IEnumerable)value2, newPath, differences);
+            }
+            // Handle complex objects recursively
+            else
+            {
+                var nestedDiffs = CompareObjects(value1, value2, newPath);
+                differences.AddRange(nestedDiffs);
+            }
+        }
+
+        private void CompareFields(FieldInfo field, object actual, object expected, string newPath, List<string> differences)
+        {
+            // if current path ends with any entry from fields to ignore, skip this field/property
+            if (ignorePaths.Any(f => newPath.EndsWith(f)))
+            {
+                return;
+            }
+
+            // Get values
+            object value1 = field.GetValue(actual);
+            object value2 = field.GetValue(expected);
+
+            Type fieldType = field.FieldType;
+
+            // Handle primitive types and strings
+            if (fieldType.IsPrimitive || fieldType == typeof(string) || fieldType.IsValueType)
+            {
+                ComparePrimitives(value1, value2, newPath, differences);
+            }
+            // Handle collections
+            else if (typeof(IEnumerable).IsAssignableFrom(fieldType))
+            {
+                CompareCollections((IEnumerable)value1, (IEnumerable)value2, newPath, differences);
+            }
+            // Handle complex objects recursively
+            else
+            {
+                var nestedDiffs = CompareObjects(value1, value2, newPath);
+                differences.AddRange(nestedDiffs);
+            }
+        }
+
+        private void ComparePrimitives(object value1, object value2, string newPath, List<string> differences)
+        {
+            if (value1 != null)
+            {
+                if (!value1.Equals(value2))
+                {
+                    differences.Add(GetDiff(newPath, value1, value2));
+                }
+            }
+            else if (value2 != null)
+            {
+                differences.Add(GetDiff(newPath, "null", value2));
+            }
+        }
+
+        private void CompareCollections(IEnumerable enumerable1, IEnumerable enumerable2, string newPath, List<string> differences)
+        {
+            var en1 = enumerable1.GetEnumerator();
+            var en2 = enumerable2.GetEnumerator();
+
+            int i = 0;
+            while (en1.MoveNext())
+            {
+                if (!en2.MoveNext())
+                {
+                    differences.Add(GetDiff(newPath, "collection size differs"));
+                    break;
+                }
+
+                string diff = CompareObjects(en1.Current, en2.Current, $"{newPath}[{i}]").FirstOrDefault();
+
+                if (diff != null)
+                {
+                    differences.Add(diff);
+                }
+
+                i++;
+            }
+
+            // in case if enumerable2 has more items, but reacheed end of enumerable1
+            if (en2.MoveNext())
+            {
+                differences.Add(GetDiff(newPath, "collection size differs"));
+            }
+        }
+
+        private string GetDiff(string path, object actual, object expected) =>
+            bullet + path +
+            Environment.NewLine + "    Expected >> " + expected +
+            Environment.NewLine + "      Actual >> " + actual;
+
+        private string GetDiff(string path, string message) =>
+            bullet + path + Environment.NewLine + "             >> " + message;
+    }
+}

--- a/src/Unicorn.Taf.Core/Utility/DeepObjectsComparer.cs
+++ b/src/Unicorn.Taf.Core/Utility/DeepObjectsComparer.cs
@@ -7,19 +7,30 @@ using System.Reflection;
 namespace Unicorn.Taf.Core.Utility
 {
     /// <summary>
-    /// Objects comparer with recursive aproach to check equality of objects considering all their public fields and properties values
+    /// Objects comparer with recursive aproach to check equality of objects considering all their public 
+    /// fields and properties values. Certain fields or properties could be excluded from comparison.
     /// </summary>
     public class DeepObjectsComparer
     {
         private string[] ignorePaths;
         private string bullet;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeepObjectsComparer"/> class.
+        /// </summary>
         public DeepObjectsComparer()
         {
             ignorePaths = new string[0];
             bullet = string.Empty;
         }
 
+        /// <summary>
+        /// Adds paths to fields/properties to ignore during comparison. 
+        /// Field or property which path ends with one of ignore paths will be skipped during comparison.
+        /// Example: SomeObject.SomeField.SomeInnerField
+        /// </summary>
+        /// <param name="ignorePaths"></param>
+        /// <returns></returns>
         public DeepObjectsComparer IgnorePaths(params string[] ignorePaths)
         {
             this.ignorePaths = ignorePaths;
@@ -37,6 +48,15 @@ namespace Unicorn.Taf.Core.Utility
             return this;
         }
 
+        /// <summary>
+        /// Compare two objects with recursive aproach to check their equality considering all public fields 
+        /// and properties values (primitives, objects, IEnumerable fields).
+        /// It there are any ignore paths specified, then fields or properties which paths ends 
+        /// with one of ignore paths will be skipped during comparison.
+        /// </summary>
+        /// <param name="actual"></param>
+        /// <param name="expected"></param>
+        /// <returns>list of differences if any, otherwise - empty list</returns>
         public List<string> CompareObjects(object actual, object expected) =>
             CompareObjects(actual, expected, "");
 

--- a/src/Unicorn.Taf.Core/Utility/DeepObjectsComparer.cs
+++ b/src/Unicorn.Taf.Core/Utility/DeepObjectsComparer.cs
@@ -29,7 +29,7 @@ namespace Unicorn.Taf.Core.Utility
         /// Field or property which path ends with one of ignore paths will be skipped during comparison.
         /// Example: SomeObject.SomeField.SomeInnerField
         /// </summary>
-        /// <param name="ignorePaths"></param>
+        /// <param name="ignorePaths">list of paths to fields/properties to be ignored</param>
         /// <returns></returns>
         public DeepObjectsComparer IgnorePaths(params string[] ignorePaths)
         {

--- a/src/Unicorn.Taf.Core/Verification/Matchers/CoreMatchers/DeepEqualToMatcher.cs
+++ b/src/Unicorn.Taf.Core/Verification/Matchers/CoreMatchers/DeepEqualToMatcher.cs
@@ -22,6 +22,13 @@ namespace Unicorn.Taf.Core.Verification.Matchers.CoreMatchers
             _objectToCompare = objectToCompare;
         }
 
+        /// <summary>
+        /// Adds paths to fields/properties to ignore during comparison. 
+        /// Field or property which path ends with one of ignore paths will be skipped during comparison.
+        /// Example: SomeObject.SomeField.SomeInnerField
+        /// </summary>
+        /// <param name="pathsToIgnore">list of paths to fields/properties to be ignored</param>
+        /// <returns></returns>
         public DeepEqualToMatcher<T> IgnoringPaths(params string[] pathsToIgnore)
         {
             this.pathsToIgnore = pathsToIgnore;

--- a/src/Unicorn.Taf.Core/Verification/Matchers/CoreMatchers/DeepEqualToMatcher.cs
+++ b/src/Unicorn.Taf.Core/Verification/Matchers/CoreMatchers/DeepEqualToMatcher.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Unicorn.Taf.Core.Utility;
+
+namespace Unicorn.Taf.Core.Verification.Matchers.CoreMatchers
+{
+    /// <summary>
+    /// Matcher to check if object is deeply equal to expected one (recursively checks all public fields and properties).
+    /// </summary>
+    /// <typeparam name="T">check items type</typeparam>
+    public class DeepEqualToMatcher<T> : TypeSafeMatcher<T>
+    {
+        private readonly T _objectToCompare;
+        private string[] pathsToIgnore;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeepEqualToMatcher{T}"/> class for specified expected object.
+        /// </summary>
+        /// <param name="objectToCompare">expected object</param>
+        public DeepEqualToMatcher(T objectToCompare)
+        {
+            _objectToCompare = objectToCompare;
+        }
+
+        public DeepEqualToMatcher<T> IgnoringPaths(params string[] pathsToIgnore)
+        {
+            this.pathsToIgnore = pathsToIgnore;
+            return this;
+        }
+            
+        /// <summary>
+        /// Gets check description.
+        /// </summary>
+        public override string CheckDescription => $"is deeply equal to '{_objectToCompare}'";
+
+        /// <summary>
+        /// Checks if object is deeply equal to expected one (recursively checks all public fields and properties).
+        /// </summary>
+        /// <param name="actual">object under check</param>
+        /// <returns>true - if actual object is deeply equal to expected one; otherwise - false</returns>
+        public override bool Matches(T actual)
+        {
+            DeepObjectsComparer comparer = new DeepObjectsComparer()
+                .UseItemsBulletsInOutput(">");
+
+            if (pathsToIgnore != null)
+            {
+                comparer.IgnorePaths(pathsToIgnore);
+            }
+
+            List<string> diff = comparer.CompareObjects(actual, _objectToCompare);
+
+            if (diff.Count == 0)
+            {
+                DescribeMismatch("objects are equal");
+                return true;
+            }
+            else
+            {
+                DescribeMismatch(string.Join(Environment.NewLine, diff));
+                return false;
+            }
+        }
+    }
+}

--- a/src/Unicorn.Taf.Core/Verification/Matchers/Is.cs
+++ b/src/Unicorn.Taf.Core/Verification/Matchers/Is.cs
@@ -20,6 +20,15 @@ namespace Unicorn.Taf.Core.Verification.Matchers
             new EqualToMatcher<T>(objectToCompare);
 
         /// <summary>
+        /// Matcher to check if actual object is deeply equal to expected one (recursively checks all public fields and properties).
+        /// </summary>
+        /// <typeparam name="T">check items type</typeparam>
+        /// <param name="objectToCompare">expected item to check equality</param>
+        /// <returns><see cref="EqualToMatcher{T}"/> instance</returns>
+        public static DeepEqualToMatcher<T> DeeplyEqualTo<T>(T objectToCompare) =>
+            new DeepEqualToMatcher<T>(objectToCompare);
+
+        /// <summary>
         /// Matcher to check if object is null.
         /// </summary>
         /// <returns><see cref="NullMatcher"/> instance</returns>

--- a/src/Unicorn.UnitTests/BO/ComplexObject.cs
+++ b/src/Unicorn.UnitTests/BO/ComplexObject.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+
+namespace Unicorn.UnitTests.BO
+{
+    public interface IObject
+    {
+
+    }
+
+    public class ComplexObject
+    {
+        private int privateIntField;
+
+        public ComplexObject()
+        {
+            PublicStringsListProperty = new List<string>();
+            PublicObjectsListProperty = new List<InnerObject>();
+        }
+
+        public InnerObject PublicNullField = null;
+        public InnerObject PublicInnerObject { get; set; } = new InnerObject();
+
+        public IObject PublicObjectWithInterface { get; set; }
+
+        public List<string> PublicStringsListProperty { get; set; }
+        public List<InnerObject> PublicObjectsListProperty { get; set; }
+
+        protected string ProtectedStringProperty { get; set; }
+        protected string ProtectedStringField;
+
+        public void SetPrivateInt(int value)
+        {
+            privateIntField = value;
+        }
+
+        public void SetProtectedStrings(string value)
+        {
+            ProtectedStringField = value;
+            ProtectedStringProperty = value;
+        }
+    }
+
+    public class Object1 : IObject
+    {
+    }
+
+    public class Object2 : IObject
+    {
+    }
+
+    public class InnerObject
+    {
+        public double PublicDouble { get; set; } = 0.3;
+
+        public string PublicString { get; set; } = "someValue";
+    }
+}

--- a/src/Unicorn.UnitTests/Tests/Core/Utility/DebugComparersOutputTests.cs
+++ b/src/Unicorn.UnitTests/Tests/Core/Utility/DebugComparersOutputTests.cs
@@ -4,13 +4,14 @@ using System.Collections.Generic;
 using System.Linq;
 using Unicorn.Taf.Core.Utility;
 using Unicorn.Taf.Core.Verification.Matchers;
+using Unicorn.UnitTests.BO;
 using Unicorn.UnitTests.Util;
 using Verify = Unicorn.Taf.Core.Verification;
 
 namespace Unicorn.UnitTests.Tests.Core.Utility
 {
     [TestFixture]
-    public class DebugOutputCollectionsComparerTests : NUnitTestRunner
+    public class DebugComparersOutputTests : NUnitTestRunner
     {
         //[Test] // Need to debug output
         public void TestCollectionsComparerOutput()
@@ -95,5 +96,23 @@ namespace Unicorn.UnitTests.Tests.Core.Utility
 
         private static List<int> IntsCollection(int from, int to) =>
             Enumerable.Range(from, to - from + 1).ToList();
+
+        //[Test]
+        public void TestDeepComparerSeveralDiffer()
+        {
+            var complexObject1 = new ComplexObject() { PublicObjectWithInterface = new Object1() };
+            complexObject1.PublicObjectsListProperty.Add(new InnerObject { PublicString = "a" });
+            complexObject1.PublicInnerObject.PublicDouble = 0.5;
+            complexObject1.PublicNullField = new InnerObject();
+
+            var complexObject2 = new ComplexObject() { PublicObjectWithInterface = new Object2() };
+            complexObject2.PublicObjectsListProperty.Add(new InnerObject { PublicString = "b" });
+            complexObject2.PublicInnerObject.PublicString = "2";
+            complexObject2.PublicStringsListProperty.Add("asd");
+
+            var result = new DeepObjectsComparer().UseItemsBulletsInOutput(">").CompareObjects(complexObject1, complexObject2);
+
+            Assert.Fail(string.Join("\r\n", result));
+        }
     }
 }

--- a/src/Unicorn.UnitTests/Tests/Core/Utility/DeepObjectsComparerTests.cs
+++ b/src/Unicorn.UnitTests/Tests/Core/Utility/DeepObjectsComparerTests.cs
@@ -1,0 +1,149 @@
+﻿using NUnit.Framework;
+using Unicorn.Taf.Core.Utility;
+using Unicorn.UnitTests.BO;
+
+namespace Unicorn.UnitTests.Tests.Core.Utility
+{
+    [TestFixture]
+    public class DeepObjectsComparerTests
+    {
+        [Test]
+        public void TestDeepComparerAllEqual()
+        {
+            var complexObject1 = new ComplexObject();
+            var complexObject2 = new ComplexObject();
+
+            var result = new DeepObjectsComparer().CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void TestDeepComparerNonPublicDiffer()
+        {
+            var complexObject1 = new ComplexObject();
+            complexObject1.SetProtectedStrings("dsf");
+            var complexObject2 = new ComplexObject();
+
+            var result = new DeepObjectsComparer().CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void TestDeepComparerPublicDiffer()
+        {
+            var complexObject1 = new ComplexObject();
+            complexObject1.PublicInnerObject.PublicDouble = 0.5;
+            var complexObject2 = new ComplexObject();
+
+            var result = new DeepObjectsComparer().CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result, Is.Not.Empty);
+        }
+
+        [Test]
+        public void TestDeepComparerPublicFieldsDiffer()
+        {
+            var complexObject1 = new ComplexObject();
+            complexObject1.PublicNullField = new InnerObject() { PublicDouble = 0.1 };
+            var complexObject2 = new ComplexObject();
+            complexObject2.PublicNullField = new InnerObject() { PublicDouble = 0.2 };
+
+            var result = new DeepObjectsComparer().CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result, Is.Not.Empty);
+        }
+
+        [Test]
+        public void TestDeepComparerListsDiffer()
+        {
+            var complexObject1 = new ComplexObject();
+            complexObject1.PublicStringsListProperty.Add("asd");
+            var complexObject2 = new ComplexObject();
+
+            var result = new DeepObjectsComparer().CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result, Is.Not.Empty);
+        }
+
+        [Test]
+        public void TestDeepComparerListItemsDiffer()
+        {
+            var complexObject1 = new ComplexObject();
+            complexObject1.PublicObjectsListProperty.Add(new InnerObject { PublicString = "a" });
+            var complexObject2 = new ComplexObject();
+            complexObject2.PublicObjectsListProperty.Add(new InnerObject { PublicString = "b" });
+
+            var result = new DeepObjectsComparer().CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result, Is.Not.Empty);
+        }
+
+
+        [Test]
+        public void TestDeepComparerSeveralDiffer()
+        {
+            var complexObject1 = new ComplexObject();
+            complexObject1.PublicObjectsListProperty.Add(new InnerObject { PublicString = "a" });
+            complexObject1.PublicInnerObject.PublicDouble = 0.5;
+            var complexObject2 = new ComplexObject();
+            complexObject2.PublicObjectsListProperty.Add(new InnerObject { PublicString = "b" });
+            complexObject2.PublicInnerObject.PublicString = "2";
+
+            var result = new DeepObjectsComparer().CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result.Count, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void TestDeepComparerListItemsDifferSecondListLonger()
+        {
+            var complexObject1 = new ComplexObject();
+            var complexObject2 = new ComplexObject();
+            complexObject2.PublicStringsListProperty.Add("asd");
+
+            var result = new DeepObjectsComparer().CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestDeepComparerIterfacePropertiesDifferByType()
+        {
+            var complexObject1 = new ComplexObject() { PublicObjectWithInterface = new Object1() };
+            var complexObject2 = new ComplexObject() { PublicObjectWithInterface = new Object2() };
+
+            var result = new DeepObjectsComparer().CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestDeepComparerIterfacePropertiesDifferWithExclusions()
+        {
+            var complexObject1 = new ComplexObject() { PublicObjectWithInterface = new Object1() };
+            var complexObject2 = new ComplexObject() { PublicObjectWithInterface = new Object2() };
+
+            var result = new DeepObjectsComparer().IgnorePaths("ComplexObject.PublicObjectWithInterface")
+                .CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void TestDeepComparerListPropertiesDifferWithExclusions()
+        {
+            var complexObject1 = new ComplexObject();
+            complexObject1.PublicObjectsListProperty.Add(new InnerObject { PublicString = "a" });
+            complexObject1.PublicObjectsListProperty.Add(new InnerObject { PublicString = "b" });
+            complexObject1.PublicObjectsListProperty.Add(new InnerObject { PublicString = "c" });
+            var complexObject2 = new ComplexObject();
+
+            var result = new DeepObjectsComparer().IgnorePaths("PublicObjectsListProperty")
+                .CompareObjects(complexObject1, complexObject2);
+
+            Assert.That(result, Is.Empty);
+        }
+    }
+}

--- a/src/Unicorn.UnitTests/Tests/Core/Verification/Matchers.cs
+++ b/src/Unicorn.UnitTests/Tests/Core/Verification/Matchers.cs
@@ -114,6 +114,34 @@ namespace Unicorn.UnitTests.Tests.Core.Verification
 
         #endregion
 
+        #region IsDeeplyEqualTo
+
+        [Test, Author("Vitaliy Dobriyan")]
+        public void TestMatcherIsDeeplyEqualToPositive()
+        {
+            ComplexObject complexObject1 = new ComplexObject();
+            complexObject1.SetProtectedStrings("dsf");
+            ComplexObject complexObject2 = new ComplexObject();
+
+            Uv.Assert.That(complexObject1, Um.Is.DeeplyEqualTo(complexObject2));
+        }
+
+        [Test, Author("Vitaliy Dobriyan")]
+        public void TestMatcherIsDeeplyEqualToNegative()
+        {
+            var complexObject1 = new ComplexObject();
+            complexObject1.PublicObjectsListProperty.Add(new InnerObject { PublicString = "a" });
+            var complexObject2 = new ComplexObject();
+            complexObject2.PublicObjectsListProperty.Add(new InnerObject { PublicString = "b" });
+
+            Assert.Throws<Uv.AssertionException>(delegate
+            {
+                Uv.Assert.That(complexObject1, Um.Is.DeeplyEqualTo(complexObject2));
+            });
+        }
+
+        #endregion
+
         #region IsOfType
 
         [Test, Author("Vitaliy Dobriyan")]


### PR DESCRIPTION
Implements #69 

Example output:
```
> ComplexObject.PublicInnerObject.PublicDouble
    Expected >> 0.3
      Actual >> 0.5
> ComplexObject.PublicInnerObject.PublicString
    Expected >> 2
      Actual >> someValue
> ComplexObject.PublicObjectWithInterface
    Expected >> has type: Unicorn.UnitTests.BO.Object2
      Actual >> has type: Unicorn.UnitTests.BO.Object1
> ComplexObject.PublicStringsListProperty
             >> collection size differs
> ComplexObject.PublicObjectsListProperty[0].PublicString
    Expected >> b
      Actual >> a
> ComplexObject.PublicNullField
    Expected >> null
      Actual >> not null
```